### PR TITLE
選択した都道府県のデータを取得する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,40 @@
+import { useState } from "react";
+
+import { usePrefectures } from "./hooks/usePrefectures";
+
 import Prefectures from "@/features/Prefectures";
 import "./App.scss";
 
 function App() {
+  const { prefs, isPending, isError, error } = usePrefectures();
+  const [selectedPrefCodes, setSelectedPrefs] = useState<number[]>([]);
+
+  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const prefCode = Number(event.target.value);
+
+    if (selectedPrefCodes.includes(prefCode)) {
+      setSelectedPrefs(selectedPrefCodes.filter((pref) => pref !== prefCode));
+    } else {
+      setSelectedPrefs([...selectedPrefCodes, prefCode]);
+    }
+  };
+
+  if (isPending) {
+    return <div>都道府県のデータ取得中...</div>;
+  }
+  if (isError) {
+    return <div>{error?.message}</div>;
+  }
+
   return (
     <>
       <h1>都道府県別の総人口・人口構成</h1>
-      <Prefectures />
+      <Prefectures prefs={prefs} onChange={handleCheckboxChange} />
+
+      <p>選択項目</p>
+      <ul>
+        {selectedPrefCodes.join(", ")}
+      </ul>
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import { useFetchPopulation, useSelectedPrefCodes, useFetchedPopulation } from "./hooks/usePopulation";
 import { usePrefectures } from "./hooks/usePrefectures";
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,27 @@
 import { useState } from "react";
 
+import { useFetchPopulation, useSelectedPrefCodes, useFetchedPopulation } from "./hooks/usePopulation";
 import { usePrefectures } from "./hooks/usePrefectures";
 
 import Prefectures from "@/features/Prefectures";
+
 import "./App.scss";
 
 function App() {
   const { prefs, isPending, isError, error } = usePrefectures();
-  const [selectedPrefCodes, setSelectedPrefs] = useState<number[]>([]);
+  const { population } = useFetchedPopulation();
+  const { selectedPrefCodes, setSelectedPrefCodes } = useSelectedPrefCodes();
+
+  useFetchPopulation();  // 選択した都道府県別のデータを取得
 
   const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const prefCode = Number(event.target.value);
 
-    if (selectedPrefCodes.includes(prefCode)) {
-      setSelectedPrefs(selectedPrefCodes.filter((pref) => pref !== prefCode));
+    if (selectedPrefCodes.has(prefCode)) {
+      selectedPrefCodes.delete(prefCode);
+      setSelectedPrefCodes(new Set(selectedPrefCodes));
     } else {
-      setSelectedPrefs([...selectedPrefCodes, prefCode]);
+      setSelectedPrefCodes(new Set([...selectedPrefCodes, prefCode]));
     }
   };
 
@@ -32,9 +38,9 @@ function App() {
       <Prefectures prefs={prefs} onChange={handleCheckboxChange} />
 
       <p>選択項目</p>
-      <ul>
-        {selectedPrefCodes.join(", ")}
-      </ul>
+      <span>{[...selectedPrefCodes].join(", ")}</span>
+      <p>取得済みデータ</p>
+      <span>{population.map((p) => p.prefCode).join(", ")}</span>
     </>
   );
 }

--- a/src/components/Checkbox.module.scss
+++ b/src/components/Checkbox.module.scss
@@ -1,0 +1,10 @@
+.checkbox {
+  padding: 2px 8px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: start;
+  cursor: pointer;
+	flex-basis: 0;
+}

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,0 +1,19 @@
+import styles from "./Checkbox.module.scss";
+
+
+type Props = {
+  value: number;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  children?: React.ReactNode;
+}
+
+export default function Checkbox({ value, onChange, children }: Props) {
+  return (
+    <div>
+      <label className={styles.checkbox} >
+        <input type="checkbox" onChange={onChange} value={value} />
+        {children}
+      </label>
+    </div>
+  );
+}

--- a/src/features/Prefectures.module.scss
+++ b/src/features/Prefectures.module.scss
@@ -1,0 +1,6 @@
+.prefectures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  flex-direction: row;
+}

--- a/src/features/Prefectures.tsx
+++ b/src/features/Prefectures.tsx
@@ -1,18 +1,23 @@
-import { usePrefectures } from "@/hooks/usePrefectures";
+import styles from "./Prefectures.module.scss";
 
-export default function Prefectures() {
-  const { prefs, isPending, isError, error } = usePrefectures();
+import Checkbox from "@/components/Checkbox";
+import { ResasPrefecture } from "@/models/APIResponseType";
 
-  if (isPending) {
-    return <div>都道府県のデータ取得中...</div>;
-  }
-  if (isError) {
-    return <div>{error?.message}</div>;
-  }
+type Props = {
+  prefs: ResasPrefecture[] | undefined;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function Prefectures({ prefs, onChange }: Props) {
   return <>
-    <span>都道府県一覧</span>
-    <ul>
-      {prefs && prefs.map((pref) => <li key={pref.prefCode}>{pref.prefName}</li>)}
-    </ul>
+    <span>都道府県</span>
+    <section className={styles.prefectures}>
+      {prefs && prefs.map((pref) => {
+        return <Checkbox key={pref.prefCode} value={pref.prefCode} onChange={onChange}>
+          {pref.prefName}
+        </Checkbox>;
+      }
+      )}
+    </section>
   </>;
 }

--- a/src/hooks/usePopulation.ts
+++ b/src/hooks/usePopulation.ts
@@ -1,0 +1,60 @@
+import { atom, useAtom } from "jotai";
+import { useEffect } from "react";
+
+import { ResasAPIResponse, ResasPopulation } from "@/models/APIResponseType";
+import { client } from "@/utils/resasClient";
+
+
+type PopulationItem = {
+  prefCode: number;
+  data: ResasPopulation[];
+}
+
+/**
+ * 取得済みの都道府県別のデータ
+ */
+const population = atom<PopulationItem[]>([]);
+export const useFetchedPopulation = () => {
+  const [_population, setPopulation] = useAtom(population);
+  return { population: _population, setPopulation };
+};
+
+/**
+ * 選択済みの都道府県コード
+ */
+const selectedPrefCodesAtom = atom<Set<number>>(new Set<number>());
+export const useSelectedPrefCodes = () => {
+  const [selectedPrefCodes, setSelectedPrefCodes] = useAtom(selectedPrefCodesAtom);
+  return { selectedPrefCodes, setSelectedPrefCodes };
+};
+
+export const useFetchPopulation = () => {
+  const { selectedPrefCodes, setSelectedPrefCodes } = useSelectedPrefCodes();
+  const { population, setPopulation } = useFetchedPopulation();
+
+  useEffect(() => {
+    const fetchPopulationData = async (prefCode: number) => {
+      // console.log(`fetch ${prefCode}`);
+      const res = await client
+        .get<ResasAPIResponse<ResasPopulation>>(
+          "/api/v1/population/composition/perYear",
+          {
+            params: { cityCode: "-", prefCode: prefCode },
+            headers: { "X-API-KEY": import.meta.env.VITE_RESAS_API_KEY }
+          }
+        );
+      setPopulation([...population, { prefCode: prefCode, data: res.data.result }]);
+      setSelectedPrefCodes(new Set([...selectedPrefCodes, prefCode]));
+    };
+
+    for (const prefCode of selectedPrefCodes) {
+      if (population.find((p) => p.prefCode === prefCode)) {
+        // console.log(`skip ${prefCode}`);
+        continue;
+      }
+
+      fetchPopulationData(prefCode);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPrefCodes, setSelectedPrefCodes]);
+};

--- a/src/models/APIResponseType.ts
+++ b/src/models/APIResponseType.ts
@@ -7,3 +7,15 @@ export type ResasPrefecture = {
   prefCode: number;
   prefName: string;
 };
+
+export type ResasPopulation = {
+  boundaryYear: number;
+  data: {
+    label: string;
+    data: {
+      year: number;
+      value: number;
+      rate?: number;  // 総人口の場合、rateは存在しない
+    }[]
+  }[]
+}


### PR DESCRIPTION
# 変更内容

- 都道府県一覧を箇条書きからチェックボックス要素に変更
- 選択中の都道府県コードのステート管理
- 選択した都道府県データの取得
  - 1度取得したものは再取得しないようにした

# 備考
- 都道府県一覧と同様に atomWithQuery 関数を用いて都道府県データの取得を試みたが、取得済みデータとの比較や返却が難しかったため、useEffect を使用して取得を行った
